### PR TITLE
Gracefully handle missing Amazon secrets

### DIFF
--- a/amazon_api.py
+++ b/amazon_api.py
@@ -1,14 +1,59 @@
+from functools import lru_cache
+
 import requests
 import streamlit as st
 
-headers = {"Authorization": f"Bearer {st.secrets['AMAZON_ACCESS_TOKEN']}"}
-MARKETPLACE_ID = st.secrets["MARKETPLACE_ID"]
-SELLER_ID = st.secrets["SELLER_ID"]
+
+def _missing_secret(secret_name: str) -> None:
+    """Display a user-friendly error and raise when a secret is missing."""
+
+    message = (
+        f"Streamlit secret '{secret_name}' is required to connect to the Amazon API. "
+        "Please add this value to your Streamlit app's configuration."
+    )
+    try:
+        st.error(message)
+    except Exception:
+        # In non-Streamlit contexts (e.g., unit tests) we still raise a clear error.
+        pass
+    raise RuntimeError(message)
+
+
+@lru_cache(maxsize=None)
+def _get_secret(secret_name: str) -> str:
+    """Safely fetch a required Streamlit secret and raise a friendly error if missing."""
+
+    try:
+        value = st.secrets[secret_name]
+    except KeyError:
+        value = None
+    except Exception:
+        value = None
+
+    if value in (None, ""):
+        _missing_secret(secret_name)
+
+    return value
+
+
+def _get_auth_headers() -> dict:
+    """Construct the authorization headers for Amazon API requests."""
+
+    access_token = _get_secret("AMAZON_ACCESS_TOKEN")
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def _get_marketplace_id() -> str:
+    return _get_secret("MARKETPLACE_ID")
+
+
+def _get_seller_id() -> str:
+    return _get_secret("SELLER_ID")
 
 def get_asin_from_ean(ean):
     url = "https://sellingpartnerapi-eu.amazon.com/catalog/v0/items"
-    params = {"MarketplaceId": MARKETPLACE_ID, "Query": ean}
-    r = requests.get(url, headers=headers, params=params)
+    params = {"MarketplaceId": _get_marketplace_id(), "Query": ean}
+    r = requests.get(url, headers=_get_auth_headers(), params=params)
     if r.status_code == 200:
         try:
             return r.json()["payload"]["Items"][0]["Identifiers"]["MarketplaceASIN"]["ASIN"]
@@ -18,8 +63,8 @@ def get_asin_from_ean(ean):
 
 def get_amazon_price(asin):
     url = f"https://sellingpartnerapi-eu.amazon.com/products/pricing/v0/items/{asin}"
-    params = {"MarketplaceId": MARKETPLACE_ID}
-    r = requests.get(url, headers=headers, params=params)
+    params = {"MarketplaceId": _get_marketplace_id()}
+    r = requests.get(url, headers=_get_auth_headers(), params=params)
     if r.status_code == 200:
         try:
             return float(r.json()["payload"][0]["Summary"]["LowestPrices"][0]["LandedPrice"]["Amount"])
@@ -31,7 +76,7 @@ def get_fba_fee(asin, price, currency="EUR"):
     url = f"https://sellingpartnerapi-eu.amazon.com/products/fees/v0/items/{asin}/feesEstimate"
     payload = {
         "FeesEstimateRequest": {
-            "MarketplaceId": MARKETPLACE_ID,
+            "MarketplaceId": _get_marketplace_id(),
             "IsAmazonFulfilled": True,
             "Identifier": asin,
             "PriceToEstimateFees": {
@@ -40,7 +85,7 @@ def get_fba_fee(asin, price, currency="EUR"):
             }
         }
     }
-    r = requests.post(url, headers=headers, json=payload)
+    r = requests.post(url, headers=_get_auth_headers(), json=payload)
     if r.status_code == 200:
         try:
             return float(r.json()["payload"]["FeesEstimateResult"]["FeesEstimate"]["TotalFeesEstimate"]["Amount"])
@@ -49,7 +94,10 @@ def get_fba_fee(asin, price, currency="EUR"):
     return None
 
 def create_listing(asin, price, quantity):
-    url = f"https://sellingpartnerapi-eu.amazon.com/listings/2021-08-01/items/{SELLER_ID}"
+    url = (
+        "https://sellingpartnerapi-eu.amazon.com/listings/2021-08-01/items/"
+        f"{_get_seller_id()}"
+    )
     payload = {
         "productType": "PRODUCT",
         "requirements": "LISTING_OFFER_ONLY",
@@ -59,5 +107,5 @@ def create_listing(asin, price, quantity):
             "price": [{"currency": "EUR", "amount": price}]
         }
     }
-    r = requests.put(url, headers=headers, json=payload)
+    r = requests.put(url, headers=_get_auth_headers(), json=payload)
     return r.json()

--- a/tests/test_amazon_api.py
+++ b/tests/test_amazon_api.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import amazon_api
+
+
+def test_get_secret_missing_shows_user_friendly_error(monkeypatch):
+    amazon_api._get_secret.cache_clear()
+
+    st_mock = Mock()
+    st_mock.secrets = {}
+    st_mock.error = Mock()
+
+    monkeypatch.setattr(amazon_api, "st", st_mock)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        amazon_api._get_secret("AMAZON_ACCESS_TOKEN")
+
+    assert "AMAZON_ACCESS_TOKEN" in str(excinfo.value)
+    st_mock.error.assert_called_once()


### PR DESCRIPTION
## Summary
- add a cached helper to lazily read Amazon API credentials and raise a user-friendly error when unavailable
- refactor Amazon API functions to build headers and payloads with the lazy credential accessor
- add a pytest covering the missing secret path to guard against regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d19a524f14832c8d409629629b0317