### PR TITLE
Improve Qogita API key handling

### DIFF
--- a/qogita_api.py
+++ b/qogita_api.py
@@ -1,8 +1,36 @@
+import os
+
 import requests
 import streamlit as st
 
+
+def _get_qogita_api_key() -> str:
+    """Fetch the Qogita API key from Streamlit secrets or the environment."""
+
+    try:
+        api_key = st.secrets.get("QOGITA_API_KEY")
+    except Exception:
+        api_key = None
+
+    if not api_key:
+        api_key = os.getenv("QOGITA_API_KEY")
+
+    if not api_key:
+        message = (
+            "Qogita API key missing. Please set st.secrets['QOGITA_API_KEY'] or "
+            "define the QOGITA_API_KEY environment variable."
+        )
+        try:
+            st.warning(message)
+        except Exception:
+            pass
+        raise RuntimeError(message)
+
+    return api_key
+
+
 def get_qogita_products(limit=50):
-    headers = {"Authorization": f"Bearer {st.secrets['QOGITA_API_KEY']}"}
+    headers = {"Authorization": f"Bearer {_get_qogita_api_key()}"}
     url = "https://api.qogita.com/v1/products"
     r = requests.get(url, headers=headers)
     data = r.json()

--- a/tests/test_qogita_api.py
+++ b/tests/test_qogita_api.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import qogita_api
+
+
+def test_get_qogita_products_returns_data(monkeypatch):
+    secrets = {"QOGITA_API_KEY": "test-key"}
+    st_mock = SimpleNamespace(secrets=secrets, warning=Mock())
+    monkeypatch.setattr(qogita_api, "st", st_mock)
+    monkeypatch.delenv("QOGITA_API_KEY", raising=False)
+
+    fake_response = Mock()
+    fake_response.json.return_value = {"data": [1, 2, 3]}
+    request_get = Mock(return_value=fake_response)
+    monkeypatch.setattr(qogita_api.requests, "get", request_get)
+
+    result = qogita_api.get_qogita_products(limit=2)
+
+    assert result == [1, 2]
+    request_get.assert_called_once()
+    headers = request_get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+
+
+def test_get_qogita_products_missing_key_raises(monkeypatch):
+    st_mock = SimpleNamespace(secrets={}, warning=Mock())
+    monkeypatch.setattr(qogita_api, "st", st_mock)
+    monkeypatch.delenv("QOGITA_API_KEY", raising=False)
+    request_get = Mock()
+    monkeypatch.setattr(qogita_api.requests, "get", request_get)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        qogita_api.get_qogita_products()
+
+    assert "QOGITA_API_KEY" in str(excinfo.value)
+    st_mock.warning.assert_called_once()
+    request_get.assert_not_called()


### PR DESCRIPTION
## Summary
- add a helper to retrieve the Qogita API key from Streamlit secrets with an environment fallback
- surface a clear RuntimeError and Streamlit warning when the credential is missing
- cover the happy path and missing-key scenarios for `get_qogita_products`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d19f5783cc832c833c7a73574665cf