### PR TITLE
Handle missing Qogita API key gracefully

### DIFF
--- a/qogita_api.py
+++ b/qogita_api.py
@@ -30,7 +30,12 @@ def _get_qogita_api_key() -> str:
 
 
 def get_qogita_products(limit=50):
-    headers = {"Authorization": f"Bearer {_get_qogita_api_key()}"}
+    try:
+        api_key = _get_qogita_api_key()
+    except RuntimeError:
+        return []
+
+    headers = {"Authorization": f"Bearer {api_key}"}
     url = "https://api.qogita.com/v1/products"
     r = requests.get(url, headers=headers)
     data = r.json()

--- a/tests/test_qogita_api.py
+++ b/tests/test_qogita_api.py
@@ -29,16 +29,15 @@ def test_get_qogita_products_returns_data(monkeypatch):
     assert headers["Authorization"] == "Bearer test-key"
 
 
-def test_get_qogita_products_missing_key_raises(monkeypatch):
+def test_get_qogita_products_missing_key_returns_empty_list(monkeypatch):
     st_mock = SimpleNamespace(secrets={}, warning=Mock())
     monkeypatch.setattr(qogita_api, "st", st_mock)
     monkeypatch.delenv("QOGITA_API_KEY", raising=False)
     request_get = Mock()
     monkeypatch.setattr(qogita_api.requests, "get", request_get)
 
-    with pytest.raises(RuntimeError) as excinfo:
-        qogita_api.get_qogita_products()
+    result = qogita_api.get_qogita_products()
 
-    assert "QOGITA_API_KEY" in str(excinfo.value)
+    assert result == []
     st_mock.warning.assert_called_once()
     request_get.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure `get_qogita_products` returns an empty list when the Qogita API key is unavailable so the Streamlit app keeps running
- update the Qogita API tests to cover the empty-list behavior when the API key is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1b9e6b698832cbc18519d4b2be00a