### PR TITLE
Handle empty product responses in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,15 +19,25 @@ for p in products:
 df = pd.DataFrame(rows)
 st.dataframe(df, use_container_width=True)
 
-profitable = df[df["Profitable"]]
-st.subheader("✅ Automatisch profitable Produkte listen")
-for _, row in profitable.iterrows():
-    resp = auto_list(row.to_dict())
-    st.write(row["Name"], resp)
+profitable = pd.DataFrame(columns=df.columns)
 
-st.download_button(
-    "📥 Export CSV",
-    data=profitable.to_csv(index=False).encode("utf-8"),
-    file_name="profitable_products.csv",
-    mime="text/csv"
-)
+if df.empty:
+    st.info("Keine Produkte gefunden. Bitte passe die Filter an und versuche es erneut.")
+elif "Profitable" not in df.columns:
+    st.info(
+        "Die Ergebnisdaten enthalten keine Spalte 'Profitable'. "
+        "Automatisches Listing und Download werden übersprungen."
+    )
+else:
+    profitable = df[df["Profitable"]]
+    st.subheader("✅ Automatisch profitable Produkte listen")
+    for _, row in profitable.iterrows():
+        resp = auto_list(row.to_dict())
+        st.write(row["Name"], resp)
+
+    st.download_button(
+        "📥 Export CSV",
+        data=profitable.to_csv(index=False).encode("utf-8"),
+        file_name="profitable_products.csv",
+        mime="text/csv"
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def test_app_handles_empty_products(monkeypatch):
+    sys.modules.pop("app", None)
+
+    fake_streamlit = ModuleType("streamlit")
+    fake_streamlit.secrets = {}
+    fake_streamlit.set_page_config = Mock()
+    fake_streamlit.title = Mock()
+    fake_streamlit.slider = Mock(return_value=10)
+    fake_streamlit.dataframe = Mock()
+    fake_streamlit.subheader = Mock()
+    fake_streamlit.write = Mock()
+    fake_streamlit.download_button = Mock()
+    fake_streamlit.info = Mock()
+    fake_streamlit.warning = Mock()
+
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+
+    fake_qogita_api = ModuleType("qogita_api")
+    fake_qogita_api.get_qogita_products = Mock(return_value=[])
+    monkeypatch.setitem(sys.modules, "qogita_api", fake_qogita_api)
+
+    fake_profit_engine = ModuleType("profit_engine")
+    fake_profit_engine.check_profit = Mock(return_value=None)
+    monkeypatch.setitem(sys.modules, "profit_engine", fake_profit_engine)
+
+    fake_auto_listing = ModuleType("auto_listing")
+    fake_auto_listing.auto_list = Mock()
+    monkeypatch.setitem(sys.modules, "auto_listing", fake_auto_listing)
+
+    try:
+        importlib.import_module("app")
+    finally:
+        monkeypatch.delitem(sys.modules, "app", raising=False)
+
+    fake_qogita_api.get_qogita_products.assert_called_once()
+    fake_streamlit.dataframe.assert_called_once()
+    fake_streamlit.info.assert_called()
+    fake_streamlit.download_button.assert_not_called()


### PR DESCRIPTION
## Summary
- guard the Streamlit app against empty results and missing `Profitable` columns before filtering
- display an informational message when profitable data is unavailable and skip the auto-list/download flow
- add a regression test that simulates no Qogita products and asserts the UI stays responsive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bc46154c832ca758afa1c15d325d