### PR TITLE
Handle Qogita API key retrieval via secrets indexing

### DIFF
--- a/qogita_api.py
+++ b/qogita_api.py
@@ -8,7 +8,11 @@ def _get_qogita_api_key() -> str:
     """Fetch the Qogita API key from Streamlit secrets or the environment."""
 
     try:
-        api_key = st.secrets.get("QOGITA_API_KEY")
+        api_key = st.secrets["QOGITA_API_KEY"]
+        if not api_key:
+            raise KeyError("QOGITA_API_KEY is empty")
+    except KeyError:
+        api_key = None
     except Exception:
         api_key = None
 

--- a/tests/test_qogita_api.py
+++ b/tests/test_qogita_api.py
@@ -10,8 +10,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import qogita_api
 
 
+class FakeSecrets:
+    def __init__(self, data):
+        self._data = data
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
 def test_get_qogita_products_returns_data(monkeypatch):
-    secrets = {"QOGITA_API_KEY": "test-key"}
+    secrets = FakeSecrets({"QOGITA_API_KEY": "test-key"})
     st_mock = SimpleNamespace(secrets=secrets, warning=Mock())
     monkeypatch.setattr(qogita_api, "st", st_mock)
     monkeypatch.delenv("QOGITA_API_KEY", raising=False)
@@ -30,7 +38,7 @@ def test_get_qogita_products_returns_data(monkeypatch):
 
 
 def test_get_qogita_products_missing_key_returns_empty_list(monkeypatch):
-    st_mock = SimpleNamespace(secrets={}, warning=Mock())
+    st_mock = SimpleNamespace(secrets=FakeSecrets({}), warning=Mock())
     monkeypatch.setattr(qogita_api, "st", st_mock)
     monkeypatch.delenv("QOGITA_API_KEY", raising=False)
     request_get = Mock()


### PR DESCRIPTION
## Summary
- fetch the Qogita API key using `st.secrets["QOGITA_API_KEY"]` and treat missing or empty values consistently before falling back to the environment
- update the Qogita API tests to use a fake secrets object without `.get()` so indexing is required

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bf6a9be8832cb1ee30f0874da7de