### PR TITLE
Ensure project root is importable during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,0 @@
-"""Test configuration helpers."""
-from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-PROJECT_ROOT = Path(__file__).resolve().parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+"""Test configuration helpers."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- add a pytest `conftest.py` that inserts the project root into `sys.path`
- ensure modules like `app` can be imported when pytest is launched via the CLI script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e6658a9098832c8f0055c75a87963a